### PR TITLE
Temporarily replace new ensure_config script for a python one liner

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -172,7 +172,7 @@ mqtt:
         put("mosquitto.service", "mosquitto.service", use_sudo=True)
         put("home-assistant_novenv.service", "home-assistant_novenv.service", use_sudo=True)
     with settings(sudo_user='hass'):
-        sudo("/srv/hass/hass_venv/bin/hass --script ensure_config --config /home/hass/.homeassistant"
+        sudo("""/srv/hass/hass_venv/bin/python3.4 -c "import homeassistant.config as config_util; config_util.ensure_config_exists('/home/hass/.homeassistant')" """)
 
     fabric.contrib.files.append("/home/hass/.homeassistant/configuration.yaml", hacfg, use_sudo=True)
     sudo("systemctl enable mosquitto.service")
@@ -265,7 +265,7 @@ mqtt:
         put("mosquitto.service", "mosquitto.service", use_sudo=True)
         put("home-assistant.service", "home-assistant.service", use_sudo=True)
     with settings(sudo_user='hass'):
-        sudo("/srv/hass/hass_venv/bin/hass --script ensure_config --config /home/hass/.homeassistant"
+        sudo("""/srv/hass/hass_venv/bin/python3.4 -c "import homeassistant.config as config_util; config_util.ensure_config_exists('/home/hass/.homeassistant')" """)
 
     fabric.contrib.files.append("/home/hass/.homeassistant/configuration.yaml", hacfg, use_sudo=True)
     sudo("systemctl enable mosquitto.service")


### PR DESCRIPTION
This is temporary until the new ensure_config script is available upstream. It's a gross one-liner. The only other idea I had was to put a script on the file system, execute it, and then unlink it. Nothing really seemed like a stellar idea. Feedback appreciated!
