### PR TITLE
Max cython version 0.24.1.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -217,7 +217,7 @@ def setup_homeassistant():
 
 def setup_openzwave():
     """ Activate Virtualenv, Install python-openzwave"""
-    sudo("source /srv/hass/hass_venv/bin/activate && pip3 install --upgrade cython", user="hass")
+    sudo("source /srv/hass/hass_venv/bin/activate && pip3 install --upgrade cython==0.24.1", user="hass")
     with cd("/srv/hass/src"):
         sudo("git clone --branch v0.3.1 https://github.com/OpenZWave/python-openzwave.git", user="hass")
         with cd("python-openzwave"):


### PR DESCRIPTION
I haven't used this script yet, but I guess it is same as this issue I PR'd (accepted) yesterday in the manual install page?

Prevent Cython v 0.25.x being downloaded and causing issues with later build process.

https://github.com/home-assistant/home-assistant.github.io/pull/1519