### PR TITLE
create an OZWCP service to make swapping between OZWCP and home assistant simple.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ To change the MQTT default password:
 To launch the OZWCP webapp:
 
 *  Login to Raspberry Pi `ssh pi@your_raspberry_pi_ip`
-*  Change to the ozwcp directory `cd /srv/homeassistant/src/open-zwave-control-panel/`
-*  Launch the control panel `sudo ./ozwcp -p 8888`
-*  Open a web browser to `http://your_pi_ip:8888`
+*  Start the ozwcp service, which will stop home assistant. `sudo systemctl start ozwcp`
+*  Open a web browser to `http://your_pi_ip:8124`
 *  Specify your zwave controller, for example `/dev/ttyACM0` and hit initialize
+*  Once finished with OZWCP start home assistant again with `sudo systemctl start home-assistant` (this will stop OZWCP).
   
 *don't check the USB box regardless of using a USB based device*
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -278,6 +278,7 @@ mqtt:
 """
     with cd("/etc/systemd/system/"):
         put("home-assistant.service", "home-assistant.service", use_sudo=True)
+        put("ozwcp.service", "ozwcp.service", use_sudo=True)
     with settings(sudo_user='homeassistant'):
         sudo("/srv/homeassistant/homeassistant_venv/bin/hass --script ensure_config --config /home/homeassistant/.homeassistant")
 

--- a/home-assistant.service
+++ b/home-assistant.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Home Assistant
 After=network.target
+Conflicts=ozwcp.service
 
 [Service]
 Type=simple

--- a/ozwcp.service
+++ b/ozwcp.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Open Z-Wave Control Panel
+After=network.target
+Conflicts=home-assistant.service
+
+[Service]
+Type=simple
+User=homeassistant
+WorkingDirectory=/srv/homeassistant/src/open-zwave-control-panel
+ExecStart=/srv/homeassistant/src/open-zwave-control-panel/ozwcp -p 8124


### PR DESCRIPTION
Starting one service stops the other, so it means it's only one command has to be issued to swap in either direction.