### PR TITLE
Remove hard coding of pip3 location

### DIFF
--- a/hass_rpi_installer.sh
+++ b/hass_rpi_installer.sh
@@ -55,10 +55,13 @@ while getopts ":n" opt; do
       echo "apt-listchanges installed. Removing."
       sudo apt-get --force-yes --yes remove apt-listchanges
     fi
-
-    sudo /usr/bin/pip3 install pycrypto
-    sudo /usr/bin/pip3 install cryptography
-    sudo /usr/bin/pip3 install fabric3
+    
+    #get path to pip
+    PIP_PATH=$(which pip)
+    
+    sudo $PIP_PATH install pycrypto
+    sudo $PIP_PATH install cryptography
+    sudo $PIP_PATH install fabric3
 
     git clone https://github.com/home-assistant/fabric-home-assistant.git
 
@@ -119,9 +122,9 @@ fi
 
 
 
-sudo /usr/bin/pip3 install pycrypto
-sudo /usr/bin/pip3 install cryptography
-sudo /usr/bin/pip3 install fabric3
+sudo /usr/local/bin/pip install pycrypto
+sudo /usr/local/bin/pip install cryptography
+sudo /usr/local/bin/pip install fabric3
 
 git clone https://github.com/home-assistant/fabric-home-assistant.git
 

--- a/hass_rpi_installer.sh
+++ b/hass_rpi_installer.sh
@@ -121,10 +121,12 @@ if [ "install ok installed" == "$PKG_APT_LISTCHANGES" ]; then
 fi
 
 
-
-sudo /usr/local/bin/pip install pycrypto
-sudo /usr/local/bin/pip install cryptography
-sudo /usr/local/bin/pip install fabric3
+#get path to pip
+PIP_PATH=$(which pip)
+    
+sudo $PIP_PATH install pycrypto
+sudo $PIP_PATH install cryptography
+sudo $PIP_PATH install fabric3
 
 git clone https://github.com/home-assistant/fabric-home-assistant.git
 


### PR DESCRIPTION
On my version of Jessie created using the PiBakery software my pip install was in a different location to the hard coded version in the script.

This should pull the correct location from which and use that instead.

Worked for me on my system.