### PR TITLE
Update fabfile.py to add support for Python 3.5 (and on)

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -3,6 +3,8 @@
 #    - deploy supporting HA components
 #    - deploy HA
 ########################################
+# Import pathlib to allow us to detect the installed version of Python
+from pathlib import Path
 
 # Import Fabric's API module
 from fabric.api import *
@@ -10,6 +12,19 @@ import fabric.contrib.files
 import time
 import os
 
+py34 = Path("/usr/local/lib/python3.4")
+py35 = Path("/usr/local/lib/python3.5")
+
+if py35.is_dir():
+    py_ver = "python3.5"
+elif py34.is_dir():
+    py_ver = "python3.4"
+    print("* WARNING *")
+    print("  Support for Python 3.4 will be removed around 1 January 2018, when aiohttp drops support for it.")
+else
+    # Let's just assume 3.6
+    py_ver = "python3.6"
+fi
 
 env.hosts = ['localhost']
 env.user = "pi"
@@ -264,7 +279,7 @@ def setup_openzwave():
 
 def setup_libcec():
     setup_libcec_novenv()
-    sudo("ln -s /usr/local/lib/python3.4/dist-packages/cec /srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages", user="homeassistant")
+    sudo("ln -s /usr/local/lib/" + py_ver + "/dist-packages/cec /srv/homeassistant/homeassistant_venv/lib/" + py_ver + "/site-packages", user="homeassistant")
 
 def setup_libmicrohttpd():
     """ Build and install libmicrohttpd """
@@ -286,9 +301,9 @@ def setup_openzwave_controlpanel():
             put("Makefile", "Makefile", use_sudo=True)
             sudo("make")
             if pi_hardware == "armv7l":
-                sudo("ln -sd /srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages/libopenzwave-0.3.3-py3.4-linux-armv7l.egg/config")
+                sudo("ln -sd /srv/homeassistant/homeassistant_venv/lib/" + py_ver + "/site-packages/libopenzwave-0.3.3-py3.4-linux-armv7l.egg/config")
             else:
-                sudo("ln -sd /srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages/libopenzwave-0.3.3-py3.4-linux-armv**6**l.egg/config")
+                sudo("ln -sd /srv/homeassistant/homeassistant_venv/lib/" + py_ver + "/site-packages/libopenzwave-0.3.3-py3.4-linux-armv**6**l.egg/config")
         sudo("chown -R homeassistant:homeassistant /srv/homeassistant/src/open-zwave-control-panel")
 
 def setup_services():


### PR DESCRIPTION
I don't have a test environment to test this unfortunately, so mostly I'm submitting this based upon my very limited Python knowledge so that it can be fixed and tested.

I didn't want to simply update it to support only 3.5, since that'll break upgrades for anybody on 3.4. I also wanted to ensure that in future it can be easily extended to support 3.6 and onwards.